### PR TITLE
Cleanup for rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,699 @@
+---
+plugins:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+AllCops:
+  NewCops: enable
+  DisplayCopNames: true
+  TargetRubyVersion: "2.7"
+  Include:
+    - "**/*.rb"
+  Exclude:
+    - bin/*
+    - ".vendor/**/*"
+    - pkg/**/*
+    - spec/fixtures/**/*
+    - vendor/**/*
+    - "**/Puppetfile"
+    - "**/Vagrantfile"
+    - "**/Guardfile"
+Layout/LineLength:
+  Description: People have wide screens, use them.
+  Max: 200
+RSpec/BeforeAfterAll:
+  Description:
+    Beware of using after(:all) as it may cause state to leak between tests.
+    A necessary evil in acceptance testing.
+  Exclude:
+    - spec/acceptance/**/*.rb
+RSpec/HookArgument:
+  Description: Prefer explicit :each argument, matching existing module's style
+  EnforcedStyle: each
+RSpec/DescribeSymbol:
+  Exclude:
+    - spec/unit/facter/**/*.rb
+Style/BlockDelimiters:
+  Description:
+    Prefer braces for chaining. Mostly an aesthetical choice. Better to
+    be consistent then.
+  EnforcedStyle: braces_for_chaining
+Style/ClassAndModuleChildren:
+  Description: Compact style reduces the required amount of indentation.
+  EnforcedStyle: compact
+Style/EmptyElse:
+  Description: Enforce against empty else clauses, but allow `nil` for clarity.
+  EnforcedStyle: empty
+Style/FormatString:
+  Description: Following the main puppet project's style, prefer the % format format.
+  EnforcedStyle: percent
+Style/FormatStringToken:
+  Description:
+    Following the main puppet project's style, prefer the simpler template
+    tokens over annotated ones.
+  EnforcedStyle: template
+Style/Lambda:
+  Description: Prefer the keyword for easier discoverability.
+  EnforcedStyle: literal
+Style/RegexpLiteral:
+  Description: Community preference. See https://github.com/voxpupuli/modulesync_config/issues/168
+  EnforcedStyle: percent_r
+Style/TernaryParentheses:
+  Description:
+    Checks for use of parentheses around ternary conditions. Enforce parentheses
+    on complex expressions for better readability, but seriously consider breaking
+    it up.
+  EnforcedStyle: require_parentheses_when_complex
+Style/TrailingCommaInArguments:
+  Description:
+    Prefer always trailing comma on multiline argument lists. This makes
+    diffs, and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArrayLiteral:
+  Description:
+    Prefer always trailing comma on multiline literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/SymbolArray:
+  Description: Using percent style obscures symbolic intent of array's contents.
+  EnforcedStyle: brackets
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+Style/Documentation:
+  Exclude:
+    - lib/puppet/parser/functions/**/*
+    - spec/**/*
+Style/WordArray:
+  EnforcedStyle: brackets
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+Style/CollectionMethods:
+  Enabled: true
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+Style/StringMethods:
+  Enabled: true
+Bundler/GemFilename:
+  Enabled: false
+Bundler/InsecureProtocolSource:
+  Enabled: false
+Gemspec/DuplicatedAssignment:
+  Enabled: false
+Gemspec/OrderedDependencies:
+  Enabled: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Gemspec/RubyVersionGlobalsUsage:
+  Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: false
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: true
+Layout/LeadingEmptyLines:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
+Lint/BigDecimalNew:
+  Enabled: false
+Lint/BooleanSymbol:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRequire:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/ErbNewArguments:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/HashCompareByIdentity:
+  Enabled: false
+Lint/IdentityComparison:
+  Enabled: false
+Lint/InterpolationCheck:
+  Enabled: false
+Lint/MissingCopEnableDirective:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/NestedPercentLiteral:
+  Enabled: false
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
+Lint/OrderedMagicComments:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/RedundantCopEnableDirective:
+  Enabled: false
+Lint/RedundantRequireStatement:
+  Enabled: false
+Lint/RedundantSafeNavigation:
+  Enabled: false
+Lint/RedundantWithIndex:
+  Enabled: false
+Lint/RedundantWithObject:
+  Enabled: false
+Lint/RegexpAsCondition:
+  Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
+Lint/SafeNavigationConsistency:
+  Enabled: false
+Lint/SafeNavigationWithEmpty:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
+Lint/ShadowedArgument:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/ToJSON:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+Lint/UnreachableLoop:
+  Enabled: false
+Lint/UriEscapeUnescape:
+  Enabled: false
+Lint/UriRegexp:
+  Enabled: false
+Lint/UselessMethodDefinition:
+  Enabled: false
+Lint/UselessTimes:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/BlockNesting:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Migration/DepartmentName:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/BlockParameterName:
+  Enabled: false
+Naming/HeredocDelimiterCase:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Performance/BindCall:
+  Enabled: false
+Performance/DeletePrefix:
+  Enabled: false
+Performance/DeleteSuffix:
+  Enabled: false
+Performance/InefficientHashSearch:
+  Enabled: false
+Performance/UnfreezeString:
+  Enabled: false
+Performance/UriDefaultParser:
+  Enabled: false
+RSpec/Be:
+  Enabled: false
+RSpec/Dialect:
+  Enabled: false
+RSpec/ContainExactly:
+  Enabled: false
+RSpec/ContextMethod:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
+RSpec/EmptyHook:
+  Enabled: false
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+RSpec/EmptyLineAfterHook:
+  Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
+RSpec/ExampleWithoutDescription:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/HooksBeforeExamples:
+  Enabled: false
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+RSpec/ImplicitSubject:
+  Enabled: false
+RSpec/LeakyConstantDeclaration:
+  Enabled: false
+RSpec/LetBeforeExamples:
+  Enabled: false
+RSpec/MatchArray:
+  Enabled: false
+RSpec/MissingExampleGroupArgument:
+  Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/MultipleSubjects:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+RSpec/PredicateMatcher:
+  Enabled: false
+RSpec/ReceiveCounts:
+  Enabled: false
+RSpec/ReceiveNever:
+  Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: false
+RSpec/RepeatedIncludeExample:
+  Enabled: false
+RSpec/ReturnFromStub:
+  Enabled: false
+RSpec/SharedExamples:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/UnspecifiedException:
+  Enabled: false
+RSpec/VariableDefinition:
+  Enabled: false
+RSpec/VoidExpect:
+  Enabled: false
+RSpec/Yield:
+  Enabled: false
+Security/Open:
+  Enabled: false
+Style/AccessModifierDeclarations:
+  Enabled: false
+Style/AccessorGrouping:
+  Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/ColonMethodDefinition:
+  Enabled: false
+Style/CombinableLoops:
+  Enabled: false
+Style/CommentedKeyword:
+  Enabled: false
+Style/Dir:
+  Enabled: false
+Style/DoubleCopDisableDirective:
+  Enabled: false
+Style/EmptyBlockParameter:
+  Enabled: false
+Style/EmptyLambdaParameter:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EvalWithLocation:
+  Enabled: false
+Style/ExpandPathArguments:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/FloatDivision:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/KeywordParametersOrder:
+  Enabled: false
+Style/MinMax:
+  Enabled: false
+Style/MixinUsage:
+  Enabled: false
+Style/MultilineWhenThen:
+  Enabled: false
+Style/NegatedUnless:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/OrAssignment:
+  Enabled: false
+Style/RandomWithOffset:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantCondition:
+  Enabled: false
+Style/RedundantConditional:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
+Style/RedundantSelfAssignment:
+  Enabled: false
+Style/RedundantSort:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/Strip:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Style/TrailingBodyOnClass:
+  Enabled: false
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+Style/TrailingBodyOnModule:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingMethodEndStatement:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: false
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+Gemspec/RequireMFA:
+  Enabled: false
+Layout/LineContinuationLeadingSpace:
+  Enabled: false
+Layout/LineContinuationSpacing:
+  Enabled: false
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: false
+Layout/SpaceBeforeBrackets:
+  Enabled: false
+Lint/AmbiguousAssignment:
+  Enabled: false
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: false
+Lint/AmbiguousRange:
+  Enabled: false
+Lint/ConstantOverwrittenInRescue:
+  Enabled: false
+Lint/DeprecatedConstants:
+  Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
+Lint/DuplicateMagicComment:
+  Enabled: false
+Lint/DuplicateMatchPattern:
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: false
+Lint/EmptyBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false
+Lint/EmptyInPattern:
+  Enabled: false
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: false
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/NonAtomicFileOperation:
+  Enabled: false
+Lint/NumberedParameterAssignment:
+  Enabled: false
+Lint/OrAssignmentToConstant:
+  Enabled: false
+Lint/RedundantDirGlobSort:
+  Enabled: false
+Lint/RefinementImportMethods:
+  Enabled: false
+Lint/RequireRangeParentheses:
+  Enabled: false
+Lint/RequireRelativeSelfPath:
+  Enabled: false
+Lint/SymbolConversion:
+  Enabled: false
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/TripleQuotes:
+  Enabled: false
+Lint/UnexpectedBlockArity:
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: false
+Lint/UselessRescue:
+  Enabled: false
+Lint/UselessRuby2Keywords:
+  Enabled: false
+Metrics/CollectionLiteralLength:
+  Enabled: false
+Naming/BlockForwarding:
+  Enabled: false
+Performance/CollectionLiteralInLoop:
+  Enabled: false
+Performance/ConcurrentMonotonicTime:
+  Enabled: false
+Performance/MapCompact:
+  Enabled: false
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: false
+Performance/RedundantSplitRegexpArgument:
+  Enabled: false
+Performance/StringIdentifierArgument:
+  Enabled: false
+RSpec/BeEq:
+  Enabled: false
+RSpec/BeNil:
+  Enabled: false
+RSpec/ChangeByZero:
+  Enabled: false
+RSpec/ClassCheck:
+  Enabled: false
+RSpec/DuplicatedMetadata:
+  Enabled: false
+RSpec/ExcessiveDocstringSpacing:
+  Enabled: false
+RSpec/IdenticalEqualityAssertion:
+  Enabled: false
+RSpec/NoExpectationExample:
+  Enabled: false
+RSpec/PendingWithoutReason:
+  Enabled: false
+RSpec/RedundantAround:
+  Enabled: false
+RSpec/SkipBlockInsideExample:
+  Enabled: false
+RSpec/SortMetadata:
+  Enabled: false
+RSpec/SubjectDeclaration:
+  Enabled: false
+RSpec/VerifiedDoubleReference:
+  Enabled: false
+Security/CompoundHash:
+  Enabled: false
+Security/IoMethods:
+  Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/ArrayIntersect:
+  Enabled: false
+Style/CollectionCompact:
+  Enabled: false
+Style/ComparableClamp:
+  Enabled: false
+Style/ConcatArrayLiterals:
+  Enabled: false
+Style/DataInheritance:
+  Enabled: false
+Style/DirEmpty:
+  Enabled: false
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+Style/EmptyHeredoc:
+  Enabled: false
+Style/EndlessMethod:
+  Enabled: false
+Style/EnvHome:
+  Enabled: false
+Style/FetchEnvVar:
+  Enabled: false
+Style/FileEmpty:
+  Enabled: false
+Style/FileRead:
+  Enabled: false
+Style/FileWrite:
+  Enabled: false
+Style/HashConversion:
+  Enabled: false
+Style/HashExcept:
+  Enabled: false
+Style/IfWithBooleanLiteralBranches:
+  Enabled: false
+Style/InPatternThen:
+  Enabled: false
+Style/MagicCommentFormat:
+  Enabled: false
+Style/MapCompactWithConditionalBlock:
+  Enabled: false
+Style/MapToHash:
+  Enabled: false
+Style/MapToSet:
+  Enabled: false
+Style/MinMaxComparison:
+  Enabled: false
+Style/MultilineInPatternThen:
+  Enabled: false
+Style/NegatedIfElseCondition:
+  Enabled: false
+Style/NestedFileDirname:
+  Enabled: false
+Style/NilLambda:
+  Enabled: false
+Style/NumberedParameters:
+  Enabled: false
+Style/NumberedParametersLimit:
+  Enabled: false
+Style/ObjectThen:
+  Enabled: false
+Style/OpenStructUse:
+  Enabled: false
+Style/OperatorMethodCall:
+  Enabled: false
+Style/QuotedSymbols:
+  Enabled: false
+Style/RedundantArgument:
+  Enabled: false
+Style/RedundantConstantBase:
+  Enabled: false
+Style/RedundantDoubleSplatHashBraces:
+  Enabled: false
+Style/RedundantEach:
+  Enabled: false
+Style/RedundantHeredocDelimiterQuotes:
+  Enabled: false
+Style/RedundantInitialize:
+  Enabled: false
+Style/RedundantLineContinuation:
+  Enabled: false
+Style/RedundantSelfAssignmentBranch:
+  Enabled: false
+Style/RedundantStringEscape:
+  Enabled: false
+Style/SelectByRegexp:
+  Enabled: false
+Style/StringChars:
+  Enabled: false
+Style/SwapValues:
+  Enabled: false

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -8,7 +8,7 @@ describe 'gpasswd' do
     'arthur',
     'ford',
     'zaphod',
-    'trillian'
+    'trillian',
   ]
 
   meddling_kids = [
@@ -16,16 +16,17 @@ describe 'gpasswd' do
     'daphne',
     'velma',
     'shaggy',
-    'scooby'
+    'scooby',
   ]
 
-  let(:manifest){<<-EOM
+  let(:manifest) do
+    <<~EOM
       $users = ['#{users.join("','")}']
       $users.each |$user| { user { $user: ensure => 'present' } }
 
       group { '#{group}': members => $users, gid => #{gid}, system => #{system}, auth_membership => #{auth_membership} }
     EOM
-  }
+  end
 
   let(:auth_membership) { true }
   let(:system) { false }
@@ -36,25 +37,23 @@ describe 'gpasswd' do
     context 'with a sorted list of users' do
       # When the tests pass with this in place, then upstream puppet has
       # achieved functionaly parity
-=begin
-      it 'should whack the module' do
-        on(host, 'rm -rf /etc/puppetlabs/code/environments/production/modules/gpasswd')
-        on(host, 'rm -rf `puppet config print vardir`/lib/*')
-      end
-=end
+      #       it 'should whack the module' do
+      #         on(host, 'rm -rf /etc/puppetlabs/code/environments/production/modules/gpasswd')
+      #         on(host, 'rm -rf `puppet config print vardir`/lib/*')
+      #       end
 
       let(:users) { hoopy_froods.sort }
 
       # Using puppet_apply as a helper
-      it 'should work with no errors' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
+      it 'works with no errors' do
+        apply_manifest_on(host, manifest, catch_failures: true)
       end
 
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest, {:catch_changes => true})
+      it 'is idempotent' do
+        apply_manifest_on(host, manifest, { catch_changes: true })
       end
 
-      it 'should have populated the group' do
+      it 'has populated the group' do
         group_members = on(host, "getent group #{group}").output.strip.split(':')[3].split(',') || []
 
         expect(group_members - users).to be_empty
@@ -65,15 +64,15 @@ describe 'gpasswd' do
       let(:users) { hoopy_froods - [hoopy_froods.last] }
 
       # Using puppet_apply as a helper
-      it 'should work with no errors' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
+      it 'works with no errors' do
+        apply_manifest_on(host, manifest, catch_failures: true)
       end
 
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest, {:catch_changes => true})
+      it 'is idempotent' do
+        apply_manifest_on(host, manifest, { catch_changes: true })
       end
 
-      it 'should have populated the group' do
+      it 'has populated the group' do
         group_members = on(host, "getent group #{group}").output.strip.split(':')[3].split(',') || []
 
         expect(group_members - users).to be_empty
@@ -84,15 +83,15 @@ describe 'gpasswd' do
       let(:users) { meddling_kids }
 
       # Using puppet_apply as a helper
-      it 'should work with no errors' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
+      it 'works with no errors' do
+        apply_manifest_on(host, manifest, catch_failures: true)
       end
 
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest, {:catch_changes => true})
+      it 'is idempotent' do
+        apply_manifest_on(host, manifest, { catch_changes: true })
       end
 
-      it 'should have populated the group' do
+      it 'has populated the group' do
         group_members = on(host, "getent group #{group}").output.strip.split(':')[3].split(',') || []
 
         expect(group_members - users).to be_empty
@@ -103,15 +102,15 @@ describe 'gpasswd' do
       let(:users) { hoopy_froods }
 
       # Using puppet_apply as a helper
-      it 'should work with no errors' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
+      it 'works with no errors' do
+        apply_manifest_on(host, manifest, catch_failures: true)
       end
 
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest, {:catch_changes => true})
+      it 'is idempotent' do
+        apply_manifest_on(host, manifest, { catch_changes: true })
       end
 
-      it 'should have populated the group' do
+      it 'has populated the group' do
         group_members = on(host, "getent group #{group}").output.strip.split(':')[3].split(',') || []
 
         expect(group_members - (users + meddling_kids)).to be_empty
@@ -124,45 +123,45 @@ describe 'gpasswd' do
       let(:gid) { '333' }
 
       # Using puppet_apply as a helper
-      it 'should work with no errors' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
+      it 'works with no errors' do
+        apply_manifest_on(host, manifest, catch_failures: true)
       end
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest, {:catch_changes => true})
+      it 'is idempotent' do
+        apply_manifest_on(host, manifest, { catch_changes: true })
       end
 
-      it 'should have populated the group' do
+      it 'has populated the group' do
         group_members = on(host, "getent group #{group}").output.strip.split(':')[3].split(',') || []
 
-        expect(group_members - ['user1','user2']).to be_empty
+        expect(group_members - ['user1', 'user2']).to be_empty
       end
 
-      it 'should have a GID of 333' do
+      it 'has a GID of 333' do
         group_gid = on(host, "getent group #{group}").output.strip.split(':')[2]
         expect(group_gid).to eq '333'
       end
     end
 
     context 'with a user that does not exist' do
-      let(:manifest) {
-        <<-EOM
+      let(:manifest) do
+        <<~EOM
           user { 'real': ensure => 'present' }
           user { 'fake': ensure => 'absent' }
           group { 'real': members => ['real','fake'] }
         EOM
-      }
-
-      it 'should add the real user to the real group' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
       end
 
-      it 'should be idempotent' do
-        apply_manifest_on(host, manifest, :catch_changes => true)
+      it 'adds the real user to the real group' do
+        apply_manifest_on(host, manifest, catch_failures: true)
+      end
+
+      it 'is idempotent' do
+        apply_manifest_on(host, manifest, catch_changes: true)
       end
     end
 
     context 'ensure that "puppet resource group" still functions' do
-      it 'should run "puppet resource group" without issue' do
+      it 'runs "puppet resource group" without issue' do
         on(host, 'puppet resource group')
       end
     end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -3,21 +3,25 @@ require 'spec_helper_acceptance'
 test_name 'gpasswd extension'
 
 describe 'gpasswd' do
-  hoopy_froods = [
-    'marvin',
-    'arthur',
-    'ford',
-    'zaphod',
-    'trillian',
-  ]
+  let(:hoopy_froods) do
+    [
+      'marvin',
+      'arthur',
+      'ford',
+      'zaphod',
+      'trillian',
+    ]
+  end
 
-  meddling_kids = [
-    'fred',
-    'daphne',
-    'velma',
-    'shaggy',
-    'scooby',
-  ]
+  let(:meddling_kids) do
+    [
+      'fred',
+      'daphne',
+      'velma',
+      'shaggy',
+      'scooby',
+    ]
+  end
 
   let(:manifest) do
     <<~EOM

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -18,7 +18,6 @@ unless ENV['BEAKER_provision'] == 'no'
   end
 end
 
-
 RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
@@ -28,29 +27,25 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
+    # Install modules and dependencies from spec/fixtures/modules
+    copy_fixture_modules_to(hosts)
     begin
-      # Install modules and dependencies from spec/fixtures/modules
-      copy_fixture_modules_to( hosts )
-      begin
-        server = only_host_with_role(hosts, 'server')
-      rescue ArgumentError =>e
-        server = only_host_with_role(hosts, 'default')
-      end
-
-      # Generate and install PKI certificates on each SUT
-      Dir.mktmpdir do |cert_dir|
-        run_fake_pki_ca_on(server, hosts, cert_dir )
-        hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
-      end
-
-      # add PKI keys
-      copy_keydist_to(server)
-    rescue StandardError, ScriptError => e
-      if ENV['PRY']
-        require 'pry'; binding.pry
-      else
-        raise e
-      end
+      server = only_host_with_role(hosts, 'server')
+    rescue ArgumentError => e
+      server = only_host_with_role(hosts, 'default')
     end
+
+    # Generate and install PKI certificates on each SUT
+    Dir.mktmpdir do |cert_dir|
+      run_fake_pki_ca_on(server, hosts, cert_dir)
+      hosts.each { |sut| copy_pki_to(sut, cert_dir, '/etc/pki/simp-testing') }
+    end
+
+    # add PKI keys
+    copy_keydist_to(server)
+  rescue StandardError, ScriptError => e
+    raise e unless ENV['PRY']
+    require 'pry'
+    binding.pry # rubocop:disable Lint/Debugger
   end
 end

--- a/spec/unit/provider/group/gpasswd_spec.rb
+++ b/spec/unit/provider/group/gpasswd_spec.rb
@@ -173,7 +173,6 @@ describe Puppet::Type.type(:group).provider(:gpasswd) do
           ),
         )
 
-        pending 'FIXME'
         expect(Puppet::Etc).to receive(:getgrnam).with('mygroup').and_return(
           Etc::Group.new('mygroup', 'x', '99999', []),
         ).at_least(:once)
@@ -215,7 +214,6 @@ describe Puppet::Type.type(:group).provider(:gpasswd) do
           ),
         )
 
-        pending 'FIXME'
         expect(Puppet::Etc).to receive(:getgrnam).with('mygroup').and_return(
           Etc::Group.new('mygroup', 'x', '99999', old_members),
         ).at_least(:once)
@@ -257,7 +255,6 @@ describe Puppet::Type.type(:group).provider(:gpasswd) do
           ),
         )
 
-        pending 'FIXME'
         expect(Puppet::Etc).to receive(:getgrnam).with('mygroup').and_return(
           Etc::Group.new('mygroup', 'x', '99999', old_members),
         ).at_least(:once)

--- a/spec/unit/provider/group/gpasswd_spec.rb
+++ b/spec/unit/provider/group/gpasswd_spec.rb
@@ -3,39 +3,41 @@ require 'spec_helper'
 require 'etc'
 
 describe Puppet::Type.type(:group).provider(:gpasswd) do
-  before do
+  let(:provider) { described_class.new(name: 'mygroup') }
+  let(:members) { nil }
+  let(:success_output) { Puppet::Util::Execution::ProcessOutput.new('', 0) }
+  let(:failure_output) { Puppet::Util::Execution::ProcessOutput.new('Failure', 1) }
+
+  let(:resource) do
+    if members
+      Puppet::Type.type(:group).new(name: 'mygroup', members: members, provider: provider)
+    else
+      Puppet::Type.type(:group).new(name: 'mygroup', provider: provider)
+    end
+  end
+
+  before(:each) do
     allow(described_class).to receive(:command).with(:add).and_return('/usr/sbin/groupadd')
     allow(described_class).to receive(:command).with(:delete).and_return('/usr/sbin/groupdel')
     allow(described_class).to receive(:command).with(:modify).and_return('/usr/sbin/groupmod')
     allow(described_class).to receive(:command).with(:addmember).and_return('/usr/bin/gpasswd')
     allow(described_class).to receive(:command).with(:modmember).and_return('/usr/bin/gpasswd')
-
-    if members
-      @resource = Puppet::Type.type(:group).new(:name => 'mygroup', :members => members, :provider => provider)
-    else
-      @resource = Puppet::Type.type(:group).new(:name => 'mygroup', :provider => provider)
-    end
   end
 
-  let(:provider) { described_class.new(:name => 'mygroup') }
-  let(:members) { nil }
-  let(:success_output) { Puppet::Util::Execution::ProcessOutput.new('', 0) }
-  let(:failure_output) { Puppet::Util::Execution::ProcessOutput.new('Failure', 1) }
-
-  describe "#create" do
-    it "should add -o when allowdupe is enabled and the group is being created" do
-      @resource[:allowdupe] = :true
-      @resource[:gid] = '555'
+  describe '#create' do
+    it 'adds -o when allowdupe is enabled and the group is being created' do
+      resource[:allowdupe] = :true
+      resource[:gid] = '555'
 
       expect(provider).to receive(:execute).with(
         '/usr/sbin/groupadd -g 555 -o mygroup',
         hash_including(
           {
-            :custom_environment => anything,
-            :failonfail         => false,
-            :combine            => true
-          }
-        )
+            custom_environment: anything,
+            failonfail: false,
+            combine: true,
+          },
+        ),
       ).and_return(success_output)
 
       # This is an unfortunate hack to prevent the parent class from
@@ -45,97 +47,97 @@ describe Puppet::Type.type(:group).provider(:gpasswd) do
         '/bin/true',
         hash_including(
           {
-            :custom_environment => anything,
-            :failonfail         => true,
-            :combine            => true
-          }
-        )
+            custom_environment: anything,
+            failonfail: true,
+            combine: true,
+          },
+        ),
       )
 
       provider.create
     end
 
-    describe "on system that feature system_groups", :if => described_class.system_groups? do
-      it "should add -r when system is enabled and the group is being created" do
-        @resource[:system] = :true
+    describe 'on system that feature system_groups', if: described_class.system_groups? do
+      it 'adds -r when system is enabled and the group is being created' do
+        resource[:system] = :true
         expect(provider).to receive(:execute).with(
           '/bin/true',
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         )
 
         expect(provider).to receive(:execute).with(
           '/usr/sbin/groupadd -r mygroup',
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => false,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: false,
+              combine: true,
+            },
+          ),
         ).and_return(success_output)
         provider.create
       end
     end
 
-    describe "on system that do not feature system_groups", :unless => described_class.system_groups? do
-      it "should not add -r when system is enabled and the group is being created" do
-        @resource[:system] = :true
+    describe 'on system that do not feature system_groups', unless: described_class.system_groups? do
+      it 'does not add -r when system is enabled and the group is being created' do
+        resource[:system] = :true
         expect(provider).to receive(:execute).with(
           '/bin/true',
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         )
 
         expect(provider).to receive(:execute).with(
           '/usr/sbin/groupadd mygroup',
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => false,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: false,
+              combine: true,
+            },
+          ),
         ).and_return(success_output)
 
         provider.create
       end
     end
 
-    describe "when adding additional group members to a new group" do
-       let(:members) { ['test_one','test_two','test_three'] }
+    describe 'when adding additional group members to a new group' do
+      let(:members) { ['test_one', 'test_two', 'test_three'] }
 
-      it "should pass all members individually as groupadd options to gpasswd" do
+      it 'passes all members individually as groupadd options to gpasswd' do
         expect(provider).to receive(:execute).with(
           '/usr/sbin/groupadd mygroup',
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => false,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: false,
+              combine: true,
+            },
+          ),
         ).and_return(success_output)
 
         expect(provider).to receive(:execute).with(
           include('/bin/true'),
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         ).at_least(:once)
 
         members.each do |member|
@@ -143,153 +145,157 @@ describe Puppet::Type.type(:group).provider(:gpasswd) do
             "/usr/bin/gpasswd -a #{member} mygroup",
             hash_including(
               {
-                :custom_environment => anything,
-                :failonfail         => false,
-                :combine            => true
-              }
-            )
+                custom_environment: anything,
+                failonfail: false,
+                combine: true,
+              },
+            ),
           ).and_return(success_output)
         end
 
+        pending 'FIXME'
         provider.create
       end
     end
 
-    describe "when adding additional group members to an existing group with no members" do
-      let(:members) { ['test_one','test_two','test_three'] }
+    describe 'when adding additional group members to an existing group with no members' do
+      let(:members) { ['test_one', 'test_two', 'test_three'] }
 
-      it "should add all new members" do
+      it 'adds all new members' do
         allow(provider).to receive(:execute).with(
           include('/bin/true'),
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         )
 
+        pending 'FIXME'
         expect(Puppet::Etc).to receive(:getgrnam).with('mygroup').and_return(
-          Etc::Group.new('mygroup','x','99999',[])
+          Etc::Group.new('mygroup', 'x', '99999', []),
         ).at_least(:once)
 
-        @resource[:auth_membership] = :false
+        resource[:auth_membership] = :false
         members.each do |member|
           expect(provider).to receive(:execute).with(
             "/usr/bin/gpasswd -a #{member} mygroup",
             hash_including(
               {
-                :custom_environment => anything,
-                :failonfail         => false,
-                :combine            => true
-              }
-            )
+                custom_environment: anything,
+                failonfail: false,
+                combine: true,
+              },
+            ),
           ).and_return(success_output)
         end
         provider.create
 
         provider.members
-        provider.members=(@resource.property('members').should)
+        provider.members = (resource.property('members').should)
       end
     end
 
-    describe "when adding additional group members to an existing group with members" do
-      let(:members) { ['test_one','test_two','test_three'] }
+    describe 'when adding additional group members to an existing group with members' do
+      let(:members) { ['test_one', 'test_two', 'test_three'] }
 
-      it "should add all new members and preserve all existing members" do
-        old_members = ['old_one','old_two','old_three','test_three']
+      it 'adds all new members and preserve all existing members' do
+        old_members = ['old_one', 'old_two', 'old_three', 'test_three']
 
         allow(provider).to receive(:execute).with(
           include('/bin/true'),
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         )
 
+        pending 'FIXME'
         expect(Puppet::Etc).to receive(:getgrnam).with('mygroup').and_return(
-          Etc::Group.new('mygroup','x','99999',old_members)
+          Etc::Group.new('mygroup', 'x', '99999', old_members),
         ).at_least(:once)
 
-        @resource[:auth_membership] = :false
+        resource[:auth_membership] = :false
         (members | old_members).each do |member|
           expect(provider).to receive(:execute).with(
             "/usr/bin/gpasswd -a #{member} mygroup",
             hash_including(
               {
-                :custom_environment => anything,
-                :failonfail         => false,
-                :combine            => true
-              }
-            )
+                custom_environment: anything,
+                failonfail: false,
+                combine: true,
+              },
+            ),
           ).and_return(success_output)
         end
         provider.create
 
         provider.members
-        provider.members=(@resource.property('members').should)
+        provider.members = (resource.property('members').should)
       end
     end
 
-    describe "when adding exclusive group members to an existing group with members" do
-      let(:members) { ['test_one','test_two','test_three'] }
+    describe 'when adding exclusive group members to an existing group with members' do
+      let(:members) { ['test_one', 'test_two', 'test_three'] }
 
-      it "should add all new members and delete all, non-matching, existing members" do
-        old_members = ['old_one','old_two','old_three','test_three']
+      it 'adds all new members and delete all, non-matching, existing members' do
+        old_members = ['old_one', 'old_two', 'old_three', 'test_three']
 
         allow(provider).to receive(:execute).with(
           include('/bin/true'),
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         )
 
+        pending 'FIXME'
         expect(Puppet::Etc).to receive(:getgrnam).with('mygroup').and_return(
-          Etc::Group.new('mygroup','x','99999',old_members)
+          Etc::Group.new('mygroup', 'x', '99999', old_members),
         ).at_least(:once)
 
-        @resource[:auth_membership] = :true
+        resource[:auth_membership] = :true
 
         expect(provider).to receive(:execute).with(
           "/usr/bin/gpasswd -M #{members.join(',')} mygroup",
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => false,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: false,
+              combine: true,
+            },
+          ),
         ).and_return(success_output)
 
         provider.create
 
         provider.members
-        provider.members=(@resource.property('members').should)
+        provider.members = (resource.property('members').should)
       end
     end
   end
 
-  describe "#gid=" do
-    it "should add -o when allowdupe is enabled and the gid is being modified" do
-      @resource[:allowdupe] = :true
+  describe '#gid=' do
+    it 'adds -o when allowdupe is enabled and the gid is being modified' do
+      resource[:allowdupe] = :true
       if Gem::Version.new(Puppet.version) >= Gem::Version.new('5.4.0')
         expect(provider).to receive(:execute).with(
           ['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'],
           hash_including(
             {
-              :custom_environment => anything,
-              :failonfail         => true,
-              :combine            => true
-            }
-          )
+              custom_environment: anything,
+              failonfail: true,
+              combine: true,
+            },
+          ),
         )
       else
         expect(provider).to receive(:execute).with(['/usr/sbin/groupmod', '-g', 150, '-o', 'mygroup'])
@@ -299,4 +305,3 @@ describe Puppet::Type.type(:group).provider(:gpasswd) do
     end
   end
 end
-


### PR DESCRIPTION
Re-creation of #35, which GitHub auto-closed when its temporary base branch (`openvox-test-stack`, #43) was merged and deleted — a closed PR's base cannot be re-pointed, so this is the same branch rebased onto master post-squash-merge.

Carries the original rubocop cleanup (baseline `.rubocop.yml`, provider and spec cleanups) plus the adaptations described in [#35's rebase comment](https://github.com/simp/puppet-gpasswd/pull/35#issuecomment): `Etc::Group` in the unit spec un-broke three of the four `pending FIXME` examples (markers removed; the `forcelocal?` one remains pending), and the acceptance member lists became `let()` for `RSpec/LeakyLocalVariable`.

rubocop: clean (1.85.1). Specs: 8 examples, 0 failures (1 pending) on Ruby 3.2, 3.4, and 4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCnDsYaJDLiP8z8tafz9Tp