### PR TITLE
Run beaker acceptance in GitHub Actions on all supported OSes

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -123,3 +123,47 @@ jobs:
       - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
+  acceptance:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - docker_alma8
+          - docker_alma9
+          - docker_alma10
+          - docker_centos9
+          - docker_centos10
+          - docker_debian11
+          - docker_debian12
+          - docker_oel8
+          - docker_oel9
+          - docker_oel10
+          - docker_rhel8
+          - docker_rhel9
+          - docker_rhel10
+          - docker_rocky8
+          - docker_rocky9
+          - docker_rocky10
+          - docker_ubuntu2204
+          - docker_ubuntu2404
+      fail-fast: false
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v7
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+      - name: bundle install
+        run: |
+          bundle install
+      - name: Setup podman
+        run: |
+          systemctl start --user podman.socket
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+      - name: beaker
+        env:
+          BEAKER_HYPERVISOR: 'docker'
+        run: |
+          bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,27 +1,15 @@
 <%
-  if ENV['BEAKER_HYPERVISOR']
-    hypervisor = ENV['BEAKER_HYPERVISOR']
-  else
-    hypervisor = 'vagrant'
-  end
+  hypervisor = ENV.fetch('BEAKER_HYPERVISOR', 'vagrant_libvirt')
 -%>
 HOSTS:
-  el7:
+  alma10:
     roles:
       - default
-    platform: el-7-x86_64
-    box: centos/7
-    hypervisor: <%= hypervisor %>
-
-  el8:
-    platform: el-8-x86_64
-    box: centos/8
+    platform: el-10-x86_64
+    box: almalinux/10
     hypervisor: <%= hypervisor %>
 
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
-  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
-<% end -%>
-
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_alma10.yml
+++ b/spec/acceptance/nodesets/docker_alma10.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  alma10:
+    roles:
+    - default
+    platform: el-10-x86_64
+    hypervisor: docker
+    image: almalinux:10
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_alma8.yml
+++ b/spec/acceptance/nodesets/docker_alma8.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  alma8:
+    roles:
+    - default
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: almalinux:8
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_alma9.yml
+++ b/spec/acceptance/nodesets/docker_alma9.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  alma9:
+    roles:
+    - default
+    platform: el-9-x86_64
+    hypervisor: docker
+    image: almalinux:9
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_centos10.yml
+++ b/spec/acceptance/nodesets/docker_centos10.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  centos10:
+    roles:
+    - default
+    platform: el-10-x86_64
+    hypervisor: docker
+    image: quay.io/centos/centos:stream10
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_centos9.yml
+++ b/spec/acceptance/nodesets/docker_centos9.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  centos9:
+    roles:
+    - default
+    platform: el-9-x86_64
+    hypervisor: docker
+    image: quay.io/centos/centos:stream9
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_debian11.yml
+++ b/spec/acceptance/nodesets/docker_debian11.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  debian11:
+    roles:
+    - default
+    platform: debian-11-amd64
+    hypervisor: docker
+    image: debian:11
+    docker_cmd: ['/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y systemd systemd-sysv openssh-server wget gnupg rsync openssl'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_debian12.yml
+++ b/spec/acceptance/nodesets/docker_debian12.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  debian12:
+    roles:
+    - default
+    platform: debian-12-amd64
+    hypervisor: docker
+    image: debian:12
+    docker_cmd: ['/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y systemd systemd-sysv openssh-server wget gnupg rsync openssl'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_oel10.yml
+++ b/spec/acceptance/nodesets/docker_oel10.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  oel10:
+    roles:
+    - default
+    platform: el-10-x86_64
+    hypervisor: docker
+    image: oraclelinux:10
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_oel8.yml
+++ b/spec/acceptance/nodesets/docker_oel8.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  oel8:
+    roles:
+    - default
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: oraclelinux:8
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_oel9.yml
+++ b/spec/acceptance/nodesets/docker_oel9.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  oel9:
+    roles:
+    - default
+    platform: el-9-x86_64
+    hypervisor: docker
+    image: oraclelinux:9
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_rhel10.yml
+++ b/spec/acceptance/nodesets/docker_rhel10.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  rhel10:
+    roles:
+    - default
+    platform: el-10-x86_64
+    hypervisor: docker
+    image: registry.access.redhat.com/ubi10/ubi-init
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_rhel8.yml
+++ b/spec/acceptance/nodesets/docker_rhel8.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  rhel8:
+    roles:
+    - default
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: registry.access.redhat.com/ubi8/ubi-init
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_rhel9.yml
+++ b/spec/acceptance/nodesets/docker_rhel9.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  rhel9:
+    roles:
+    - default
+    platform: el-9-x86_64
+    hypervisor: docker
+    image: registry.access.redhat.com/ubi9/ubi-init
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_rocky10.yml
+++ b/spec/acceptance/nodesets/docker_rocky10.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  rocky10:
+    roles:
+    - default
+    platform: el-10-x86_64
+    hypervisor: docker
+    image: rockylinux/rockylinux:10
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_rocky8.yml
+++ b/spec/acceptance/nodesets/docker_rocky8.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  rocky8:
+    roles:
+    - default
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: rockylinux:8
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_rocky9.yml
+++ b/spec/acceptance/nodesets/docker_rocky9.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  rocky9:
+    roles:
+    - default
+    platform: el-9-x86_64
+    hypervisor: docker
+    image: rockylinux:9
+    docker_cmd: ['/usr/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'yum install -y rsync openssl openssh-server'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_ubuntu2204.yml
+++ b/spec/acceptance/nodesets/docker_ubuntu2204.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  ubuntu2204:
+    roles:
+    - default
+    platform: ubuntu-22.04-amd64
+    hypervisor: docker
+    image: ubuntu:22.04
+    docker_cmd: ['/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y systemd systemd-sysv openssh-server wget gnupg rsync openssl'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/docker_ubuntu2404.yml
+++ b/spec/acceptance/nodesets/docker_ubuntu2404.yml
@@ -1,0 +1,20 @@
+---
+HOSTS:
+  ubuntu2404:
+    roles:
+    - default
+    platform: ubuntu-24.04-amd64
+    hypervisor: docker
+    image: ubuntu:24.04
+    docker_cmd: ['/sbin/init']
+    docker_preserve_image: true
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y systemd systemd-sysv openssh-server wget gnupg rsync openssl'
+    dockeropts:
+      HostConfig:
+        Memory: 536870912
+        Privileged: true
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,51 +1,28 @@
 require 'beaker-rspec'
-require 'tmpdir'
-require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
-    # Install Puppet
+    # Install the openvox agent (per BEAKER_PUPPET_COLLECTION/puppet_collection)
     if host.is_pe?
       install_pe
     else
       install_puppet
     end
-    # Install git, it's a dependency for inspec profiles
-    # Found this when experiencing https://github.com/chef/inspec/issues/1270
-    install_package(host, 'git')
   end
 end
 
 RSpec.configure do |c|
-  # ensure that environment OS is ready on each host
-  fix_errata_on hosts
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
 
   # Readable test descriptions
   c.formatter = :documentation
 
-  # Configure all nodes in nodeset
   c.before :suite do
     # Install modules and dependencies from spec/fixtures/modules
     copy_fixture_modules_to(hosts)
-    begin
-      server = only_host_with_role(hosts, 'server')
-    rescue ArgumentError => e
-      server = only_host_with_role(hosts, 'default')
-    end
-
-    # Generate and install PKI certificates on each SUT
-    Dir.mktmpdir do |cert_dir|
-      run_fake_pki_ca_on(server, hosts, cert_dir)
-      hosts.each { |sut| copy_pki_to(sut, cert_dir, '/etc/pki/simp-testing') }
-    end
-
-    # add PKI keys
-    copy_keydist_to(server)
-  rescue StandardError, ScriptError => e
-    raise e unless ENV['PRY']
-    require 'pry'
-    binding.pry # rubocop:disable Lint/Debugger
   end
 end


### PR DESCRIPTION
Adds beaker-docker acceptance testing to CI for **every supported OS with a container image** — 18 nodes: AlmaLinux/Rocky/OracleLinux/RHEL(UBI) 8-10, CentOS Stream 9/10, Debian 11/12, Ubuntu 22.04/24.04.

### Notes
- **Dockerfile exec form for init**: `docker_cmd` is now an array (`['/sbin/init']`). beaker-docker interpolates a string value as Dockerfile *shell form* (`CMD /sbin/init`), which leaves systemd unable to run as PID 1 — the Debian-family containers died at boot with *"Couldn't find an alternative telinit implementation to spawn"*. Array values interpolate as exec form, which boots cleanly (and is harmless-to-better for the EL images).
- The Debian/Ubuntu nodesets bootstrap systemd + sshd in the image build; the openvox agent installs via the standard `puppet_collection: openvox8` flow (beaker_puppet_helpers handles apt).
- `spec_helper_acceptance.rb` drops the fake-PKI/keydist boilerplate this module never used.
- The stale CentOS 7/8 vagrant `default.yml` is replaced with AlmaLinux 10 (`BEAKER_HYPERVISOR` still overridable).

### Verified locally (podman, rootless — same as the GHA setup)
- `docker_debian12`: 19 examples, 0 failures
- `docker_ubuntu2404`: 19 examples, 0 failures
- `docker_alma10`: 19 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)