### PR TITLE
Rename module to simp-gpasswd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@
 - Drop end-of-life OS support (EL6/EL7, Debian 9/10, Ubuntu 16.04,
   OpenSUSE); list EL8-10, Debian 11/12, and Ubuntu 22.04/24.04
 - Point source and issue URLs at the simp/puppet-gpasswd repository
+- Rename the module from onyxpoint-gpasswd to simp-gpasswd so Forge
+  deployment publishes to the namespace the SIMP org can write to; the
+  RPM obsoletes pupmod-onyxpoint-gpasswd for upgrades
 - Drop GitLab CI configuration and adopt the SIMP renovate presets
 - Sync GitHub Actions workflows with the current SIMP baseline
 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Trevor Vaughan <tvaughan@onyxpoint.com>
 Support
 -------
 
-Please log tickets and issues at our [Gpasswd Github Site](https://github.com/onyxpoint/puppet-gpasswd/issues)
+Please log tickets and issues at our [Gpasswd Github Site](https://github.com/simp/puppet-gpasswd/issues)

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,0 +1,2 @@
+# Drop all Requires, Obsoletes, and Provides statements in here
+Obsoletes: pupmod-onyxpoint-gpasswd < 2.0.0

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
-  "name": "onyxpoint-gpasswd",
+  "name": "simp-gpasswd",
   "version": "2.0.0",
-  "author": "Trevor Vaughan <tvaughan@onyxpoint.com>",
+  "author": "SIMP Team",
   "summary": "Adds support for :manages_members to the Linux group native type",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/puppet-gpasswd",


### PR DESCRIPTION
The `deploy-to-puppet-forge` job publishes with the SIMP org's `PUPPETFORGE_API_TOKEN`, which cannot write to the `onyxpoint` namespace — which is why nothing has reached the Forge since 1.1.2 (Feb 2021; the 1.1.3 tag never published). Renaming to `simp-gpasswd` before the 2.0.0 tag means the first release under the new name simply creates the module in the namespace the token owns.

- `metadata.json`: `name` → `simp-gpasswd`, `author` → `SIMP Team` (matching the fleet; Trevor's credit remains in the README/CHANGELOG)
- `build/rpm_metadata/requires`: `Obsoletes: pupmod-onyxpoint-gpasswd < 2.0.0` so RPM upgrades are seamless
- README: stale onyxpoint issues link → this repo
- CHANGELOG: bullet added to the unreleased 2.0.0 entry (no extra version bump needed)

Verified locally: metadata_lint, spec (8/8, 1 pending), RELENG checks, and `pupmod:build` (produces `simp-gpasswd-2.0.0.tar.gz`).

Companion PR updates the `mod 'onyxpoint-gpasswd'` entries in the simp-core Puppetfiles. The old `onyxpoint/gpasswd` Forge listing can only be deprecated by its owner (or via a Puppet support transfer) — worth a follow-up ticket if you want the old listing to point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)